### PR TITLE
Fix Drone push_quay_tag build step - using correct image tag from build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,8 +33,8 @@ steps:
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
   commands:
     - docker login -u="ukhomeofficedigital+alpine" -p=$${DOCKER_TOKEN} quay.io
-    - docker tag alpine quay.io/ukhomeofficedigital/alpine:latest
-    - docker tag alpine quay.io/ukhomeofficedigital/alpine:$${DRONE_TAG}
+    - docker tag alpine:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/alpine:latest
+    - docker tag alpine:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/alpine:$${DRONE_TAG}
     - docker push quay.io/ukhomeofficedigital/alpine:latest
     - docker push quay.io/ukhomeofficedigital/alpine:$${DRONE_TAG}
   environment:


### PR DESCRIPTION
* Use correct Docker image tag from `build` step when `push_quay_tag`
  * not sure how this ever worked previously as `alpine:latest` woudln't have existed in the current or previous version of `drone.yml` - better to use explicit tag versions anyway

Fixes build failure https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/docker-alpine/34/1/4