### PR TITLE
Upgrade alpine to 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 RUN adduser -D -u 1001 alpine
 


### PR DESCRIPTION
Alpine 3.14 was released on 2021-06-15 and a subsequent patch
version on 2021-08-04. This change brings the version of this 
image up to date with the latest release version.