### PR TITLE
Update Alpine to 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
 RUN adduser -D -u 1001 alpine
 


### PR DESCRIPTION
Alpine 3.15 was released on 2021-11-24. This change brings the version of this 
image up to date with the latest release version.